### PR TITLE
Fix Compilation Error: Change sync to async in detectHands

### DIFF
--- a/src/sign_recognizer/sign_recognizer.ts
+++ b/src/sign_recognizer/sign_recognizer.ts
@@ -261,7 +261,7 @@ export class SignRecognizer {
    * @param elem Video element where the sign to recognize is
    * @returns A HandLandmarkerResult object containing the hand landmarks.
    */
-   sync detectHands(elem: HTMLVideoElement): Promise<HandLandmarkerResult | null> {
+   async detectHands(elem: HTMLVideoElement): Promise<HandLandmarkerResult | null> {
     if (!this.handLandmarker) {
       console.warn("Hand Landmarker model is not loaded yet!");
       return null;


### PR DESCRIPTION
This pull request resolves a compilation error in the SignRecognizer class caused by the detectHands method being incorrectly declared with sync instead of async.

Key Changes:
Updated the detectHands method in src/sign_recognizer/sign_recognizer.ts from sync to async.
This fix ensures the method handles asynchronous operations correctly and addresses the compilation issue caused by the incorrect declaration.

![image](https://github.com/user-attachments/assets/c73c2837-9965-4b53-bc4c-7392df2d0515)